### PR TITLE
Potential fix for code scanning alert no. 8: Prototype-polluting function

### DIFF
--- a/utils/media_messages.js
+++ b/utils/media_messages.js
@@ -39,6 +39,9 @@ export function editMessageProptery(message, propertyPath, value) {
 
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
+    if (key === '__proto__' || key === 'constructor') {
+      throw new Error('Prototype pollution attempt detected');
+    }
     if (!(key in current)) {
       throw new Error(`"${propertyPath}" does not exist in message`);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/AstroX11/Xstro/security/code-scanning/8](https://github.com/AstroX11/Xstro/security/code-scanning/8)

To fix the prototype pollution issue, we need to ensure that the function `editMessageProptery` does not allow modification of special properties like `__proto__` and `constructor`. This can be achieved by adding checks to block these properties during the traversal and modification process.

- Add a check to block the `__proto__` and `constructor` properties in the `propertyPath` keys.
- Ensure that these checks are applied before modifying the `current` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
